### PR TITLE
fix: correct the logs

### DIFF
--- a/ic2datadog.py
+++ b/ic2datadog.py
@@ -45,7 +45,6 @@ ic_api_key = os.getenv('IC_API_KEY', default_value)
 ic_tags = os.getenv('IC_TAGS', 'environment:development').split(',')
 dd_metric_prefix = os.getenv('DD_METRIC_PREFIX', 'instaclustr')
 sleepy = int(os.getenv('TIME_BETWEEN_FETCH', 30))
-
 ## Added regex for topics we want to scrape.
 ic_topic_regex = os.getenv('IC_TOPIC_REGEX', default_value)
 

--- a/instaclustr/instaclustr.py
+++ b/instaclustr/instaclustr.py
@@ -118,7 +118,7 @@ async def getInstaclustrConsumerGroupMetrics(cluster_id, consumer_group, topic, 
     session = aiohttp.ClientSession()
     async with session.get(url=target, auth=auth_details,  headers=headers) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupMetrics {0}'.format(response))
-        if (response.status != 200 or response.headers['Content-Type'] != 'application/json') and 'Content-Type' in response.headers:
+        if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
         else:
@@ -141,7 +141,7 @@ async def getInstaclustrConsumerGroupClientMetrics(cluster_id, consumer_group, t
     session = aiohttp.ClientSession()
     async with session.get(url=target, auth=auth_details,  headers=headers) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupClientMetrics {0}'.format(response))
-        if (response.status != 200 or response.headers['Content-Type'] != 'application/json') and 'Content-Type' in response.headers:
+        if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group client metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
         else:

--- a/instaclustr/instaclustr.py
+++ b/instaclustr/instaclustr.py
@@ -30,7 +30,8 @@ ic_consumer_group_client_metrics_url = os.getenv('IC_CONSUMER_GROUP_CLIENT_METRI
 /clusters/{0}/kafka/consumerGroupClientMetrics?consumerGroup={1}&topic={2}&metrics=consumerLag,consumerCount,partitionCount')
 default_value = ''
 ic_rate_limiting_header = os.getenv('IC_RATE_LIMIT_KEY', default_value)
-headers={'ic-rate-limit-override':ic_rate_limiting_header}
+headers = {'ic-rate-limit-override': ic_rate_limiting_header}
+
 
 def envkey(*args, auth={}, **kwargs):
     key = hashkey(*args, **kwargs)
@@ -43,7 +44,7 @@ async def getInstaclustrMetrics(cluster_id, metrics_list, auth={}, index=0, dump
     auth_details = aiohttp.BasicAuth(login=auth.get("ic_user_name"), password=auth.get("ic_api_key"))
     target = ic_topic_metrics_url.format(cluster_id, ','.join(metrics_list))
     session = aiohttp.ClientSession()
-    async with session.get(url=target, auth=auth_details,  headers=headers) as response:
+    async with session.get(url=target, auth=auth_details, headers=headers) as response:
         logger.info('Debugging Error getInstaclustrMetrics {0}'.format(response))
         if response.status != 200 or response.headers['Content-Type'] != 'application/json':
             logger.error('Missing metrics data from instaclustr - HTTP response code: {0}; \
@@ -116,7 +117,7 @@ async def getInstaclustrConsumerGroupMetrics(cluster_id, consumer_group, topic, 
     auth_details = aiohttp.BasicAuth(login=auth.get("ic_user_name"), password=auth.get("ic_api_key"))
     target = ic_consumer_group_metrics_url.format(cluster_id, consumer_group, topic)
     session = aiohttp.ClientSession()
-    async with session.get(url=target, auth=auth_details,  headers=headers) as response:
+    async with session.get(url=target, auth=auth_details, headers=headers) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupMetrics {0}'.format(response))
         if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group metrics data from instaclustr - HTTP response code: {0}; \
@@ -139,7 +140,7 @@ async def getInstaclustrConsumerGroupClientMetrics(cluster_id, consumer_group, t
     auth_details = aiohttp.BasicAuth(login=auth.get("ic_user_name"), password=auth.get("ic_api_key"))
     target = ic_consumer_group_client_metrics_url.format(cluster_id, consumer_group, topic)
     session = aiohttp.ClientSession()
-    async with session.get(url=target, auth=auth_details,  headers=headers) as response:
+    async with session.get(url=target, auth=auth_details, headers=headers) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupClientMetrics {0}'.format(response))
         if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group client metrics data from instaclustr - HTTP response code: {0}; \

--- a/instaclustr/instaclustr.py
+++ b/instaclustr/instaclustr.py
@@ -116,9 +116,11 @@ async def getInstaclustrConsumerGroupMetrics(cluster_id, consumer_group, topic, 
     session = aiohttp.ClientSession()
     async with session.get(url=target, auth=auth_details) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupMetrics {0}'.format(response))
-        if response.status != 200 or response.headers['Content-Type'] != 'application/json':
+        if (response.status != 200 or response.headers['Content-Type'] != 'application/json') and 'Content-Type' in response.headers:
             logger.error('Missing consumer group metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
+        else:
+            logger.error('Missing consumer group metrics data from instaclustr {0}'.format(response))
             logger.error(target)
             await session.close()
             return None
@@ -137,10 +139,11 @@ async def getInstaclustrConsumerGroupClientMetrics(cluster_id, consumer_group, t
     session = aiohttp.ClientSession()
     async with session.get(url=target, auth=auth_details) as response:
         logger.info('Debugging Error getInstaclustrConsumerGroupClientMetrics {0}'.format(response))
-        if response.status != 200 or response.headers['Content-Type'] != 'application/json':
+        if (response.status != 200 or response.headers['Content-Type'] != 'application/json') and 'Content-Type' in response.headers:
             logger.error('Missing consumer group client metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
-            logger.error(target)
+        else:
+            logger.error('Missing consumer group client metrics data from instaclustr - HTTP response : {0};'.format(response))
             await session.close()
             return None
         metrics = await response.text()

--- a/instaclustr/instaclustr.py
+++ b/instaclustr/instaclustr.py
@@ -122,8 +122,6 @@ async def getInstaclustrConsumerGroupMetrics(cluster_id, consumer_group, topic, 
         if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
-        else:
-            logger.error('Missing consumer group metrics data from instaclustr {0}'.format(response))
             logger.error(target)
             await session.close()
             return None
@@ -145,8 +143,6 @@ async def getInstaclustrConsumerGroupClientMetrics(cluster_id, consumer_group, t
         if (response.status != 200 or response.headers['Content-Type'] != 'application/json'):
             logger.error('Missing consumer group client metrics data from instaclustr - HTTP response code: {0}; \
 HTTP Header Content-Type: {1}'.format(response.status, response.headers['Content-Type']))
-        else:
-            logger.error('Missing consumer group client metrics data from instaclustr - HTTP response : {0};'.format(response))
             await session.close()
             return None
         metrics = await response.text()


### PR DESCRIPTION
The new key is to be used in the header of the API calls, we should also use the existing monitoring API key, but add a new header named ic-rate-limit-override.